### PR TITLE
ci: update Node.js version from 20.x to 22.x in GitHub Actions workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20.x'
+        node-version: '22.x'
     - run: npm ci
     - run: npm run build --if-present
 


### PR DESCRIPTION
- Updated Node.js version in `.github/workflows/CI.yml` from 20.x to 22.x.
- Ensures the workflow uses the latest Node.js version during CI build.