### PR TITLE
Add CD workflow trigger to CI pipeline

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,3 +40,18 @@ jobs:
         docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .
         docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
         echo "image=$REGISTRY/$REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+    - name: Trigger CD Workflow
+      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+      run: |
+        curl -X POST \
+          -H "Authorization: token ${{ secrets.CD_PAT_TOKEN }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/SHEVA-INC/sheva-infrastructure/dispatches \
+          -d '{
+            "event_type": "deploy-ui",
+            "client_payload": {
+              "service": "ui",
+              "image_tag": "${{ github.sha }}"
+            }
+          }'


### PR DESCRIPTION
- Implement a new step to trigger the CD workflow after successful CI.
- Only trigger on push events to the main branch.
- Use GitHub API to dispatch a custom event to the infrastructure repository.
- Include service name and image tag in the payload for deployment.